### PR TITLE
Add Vim Unimpaired plugin for better buffer nav

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -41,6 +41,7 @@ Plug 'tpope/vim-repeat'
 Plug 'tpope/vim-surround'
 Plug 'vim-ruby/vim-ruby'
 Plug 'wakatime/vim-wakatime'
+Plug 'tpope/vim-unimpaired'
 
 " Autocomplete
 Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }


### PR DESCRIPTION
Instead of using `:bn` and `:bp` to cycle through buffers, unimpaired adds `[b` and `]b`. There are also other useful pairs added.